### PR TITLE
Added 'inputmode' property to html inputs.

### DIFF
--- a/angular-code-input/src/lib/code-input.component.config.ts
+++ b/angular-code-input/src/lib/code-input.component.config.ts
@@ -5,6 +5,7 @@ export const CodeInputComponentConfigToken = new InjectionToken<CodeInputCompone
 export interface CodeInputComponentConfig {
   codeLength?: number;
   inputType?: string;
+  inputMode?: string;
   initialFocusField?: number;
   isCharsCode?: boolean;
   isCodeHidden?: boolean;
@@ -18,6 +19,7 @@ export interface CodeInputComponentConfig {
 export const defaultComponentConfig: CodeInputComponentConfig = {
   codeLength: 4,
   inputType: 'tel',
+  inputMode: 'numeric',
   initialFocusField: undefined,
   isCharsCode: false,
   isCodeHidden: false,

--- a/angular-code-input/src/lib/code-input.component.html
+++ b/angular-code-input/src/lib/code-input.component.html
@@ -6,6 +6,7 @@
          (input)="onInput($event, i)"
          (keydown)="onKeydown($event, i)"
          [type]="inputType"
+         [inputmode]="inputMode"
          [disabled]="disabled"
          [attr.autocapitalize]="autocapitalize"
          autocomplete="one-time-code"/>

--- a/angular-code-input/src/lib/code-input.component.ts
+++ b/angular-code-input/src/lib/code-input.component.ts
@@ -39,6 +39,7 @@ export class CodeInputComponent implements AfterViewInit, OnInit, OnChanges, OnD
 
   @Input() codeLength !: number;
   @Input() inputType !: string;
+  @Input() inputMode !: string;
   @Input() initialFocusField?: number;
   /** @deprecated Use isCharsCode prop instead. */
   @Input() isNonDigitsCode = false;


### PR DESCRIPTION
Hello!

Setting a specific keyboard on mobile devices may not be enough via the `<input type="...">` property.
Therefore I also added the `inputmode` property and made it available as an @Input() variable.