### PR TITLE
style(onBackValue): show that the element is selected

### DIFF
--- a/angular-code-input/src/lib/code-input.component.ts
+++ b/angular-code-input/src/lib/code-input.component.ts
@@ -412,6 +412,9 @@ export class CodeInputComponent implements AfterViewInit, OnInit, OnChanges, OnD
     const isEmpty = this.isEmpty(value);
     const valueClassCSS = 'has-value';
     const emptyClassCSS = 'empty';
+    
+    input.select();
+    
     if (isEmpty) {
       input.value = '';
       input.classList.remove(valueClassCSS);


### PR DESCRIPTION
When we click on the back button, we do not see that the element is selected.
This pull-request aim to correct that

|Before|After|
|---|---|
|![image](https://github.com/AlexMiniApps/angular-code-input/assets/44493964/896b7ebb-389f-4040-a82a-43bf6b33e2ec)|![image](https://github.com/AlexMiniApps/angular-code-input/assets/44493964/e9c91ac8-f1e4-4e3b-9bfd-635041adeec8)|