### PR TITLE
Add option to clear previous input on backspace

### DIFF
--- a/angular-code-input/src/lib/code-input.component.config.ts
+++ b/angular-code-input/src/lib/code-input.component.config.ts
@@ -14,6 +14,7 @@ export interface CodeInputComponentConfig {
   code?: string | number;
   disabled?: boolean;
   autocapitalize?: string;
+  isClearPreviousIfEmpty?: boolean;
 }
 
 export const defaultComponentConfig: CodeInputComponentConfig = {
@@ -27,5 +28,6 @@ export const defaultComponentConfig: CodeInputComponentConfig = {
   isFocusingOnLastByClickIfFilled: false,
   code: undefined,
   disabled: false,
-  autocapitalize: undefined
+  autocapitalize: undefined,
+  isClearPreviousIfEmpty: false
 };

--- a/angular-code-input/src/lib/code-input.component.ts
+++ b/angular-code-input/src/lib/code-input.component.ts
@@ -50,6 +50,7 @@ export class CodeInputComponent implements AfterViewInit, OnInit, OnChanges, OnD
   @Input() code ?: string | number;
   @Input() disabled !: boolean;
   @Input() autocapitalize ?: string;
+  @Input() isClearPreviousIfEmpty!: boolean;
 
   @Output() readonly codeChanged = new EventEmitter<string>();
   @Output() readonly codeCompleted = new EventEmitter<string>();
@@ -269,13 +270,18 @@ export class CodeInputComponent implements AfterViewInit, OnInit, OnChanges, OnD
       this.emitChanges();
     }
 
-    // preventing to focusing on the previous field if it does not exist or the delete key has been pressed
+    // preventing to focusing/clearing on the previous field if it does not exist or the delete key has been pressed
     if (prev < 0 || isDeleteKey) {
       return;
     }
 
     if (isTargetEmpty || this.isPrevFocusableAfterClearing) {
       this.inputs[prev].focus();
+    }
+
+
+    if (isTargetEmpty && this.isClearPreviousIfEmpty) {
+      this.setInputValue(this.inputs[prev], null);
     }
   }
 


### PR DESCRIPTION
Consider adding this functionality for a different user experience while deleting:

Added an option to delete the previous character when the current input is empty.

Use case: User enters a wrong character and wants to delete it. Currently on an empty input with backspace is taken to the previous input but could be misled by the fact that the input still has the value.


Example:
without new isClearPreviousIfEmpty option:
[old.webm](https://github.com/AlexMiniApps/angular-code-input/assets/26444579/0f49e1cf-7b8f-4282-90b5-13b44040dac5)


with new isClearPreviousIfEmpty option:
[new.webm](https://github.com/AlexMiniApps/angular-code-input/assets/26444579/c443e430-bfa4-4a1c-8aab-cb1517222b5b)

isClearPreviousIfEmpty + isPrevFocusableAfterClearing:
[isClearPreviousIfEmpty + isPrevFocusableAfterClearing.webm](https://github.com/AlexMiniApps/angular-code-input/assets/26444579/4852c594-dbbf-4512-95c0-6fd935a17b97)

